### PR TITLE
Added an IGV goto URL for the variant view.

### DIFF
--- a/puzzle/blueprints/variants/templates/variant.html
+++ b/puzzle/blueprints/variants/templates/variant.html
@@ -48,7 +48,8 @@
 				<li class="list-group-item">
 					Position
 					<div class="pull-right">
-						{{ variant.CHROM }}:{{ variant.POS }} |
+						<a href=http://localhost:60151/goto?locus={{ variant.CHROM }}:{{ variant.POS }}>
+						  {{ variant.CHROM }}:{{ variant.POS }}</a> |
 
 						{{ variant.REF }}
 						<span class="glyphicon glyphicon-arrow-right"></span>


### PR DESCRIPTION
I found this useful when browsing variants locally. Assuming I can open a bam file in IGV somehow, I can jump directly to the right spot from puzzle. The http interface allows loading as well, but then one needs to decide on how/where to put the bam data. https://www.broadinstitute.org/igv/ControlIGV