### PR TITLE
Use dataTables.js

### DIFF
--- a/puzzle/blueprints/variants/templates/macros/compounds.html
+++ b/puzzle/blueprints/variants/templates/macros/compounds.html
@@ -1,5 +1,5 @@
 {% macro compounds_table(compound_variants, case_id) -%}
-	<table class="table table-bordered table-hover">
+	<table class="table table-bordered table-hover" id="compounds_list">
 		<caption>Compounds</caption>
 		<thead>
 			<tr>

--- a/puzzle/blueprints/variants/templates/macros/genes.html
+++ b/puzzle/blueprints/variants/templates/macros/genes.html
@@ -1,6 +1,6 @@
 {% macro gene_table(genes) %}
 	<div class="table-responsive">
-		<table class="table table-bordered table-hover">
+		<table class="table table-bordered table-hover" id="genes_list">
 			<caption>Genes</caption>
 			<thead>
 				<tr>

--- a/puzzle/blueprints/variants/templates/macros/transcripts.html
+++ b/puzzle/blueprints/variants/templates/macros/transcripts.html
@@ -1,6 +1,6 @@
 {% macro vep_transcripts(transcripts) %}
 	<div class="table-responsive">
-		<table class="table table-bordered table-hover">
+		<table class="table table-bordered table-hover" id="transcripts_list">
 			<caption>Transcripts</caption>
 			<thead>
 				<tr>

--- a/puzzle/blueprints/variants/templates/sv_variant.html
+++ b/puzzle/blueprints/variants/templates/sv_variant.html
@@ -154,3 +154,15 @@
 	{% endif %}
 {% endblock %}
 
+{% block js_bottom %}
+  {{ super() }}
+  <script type="text/javascript" charset="utf-8">
+  $(document).ready(function(){
+    $('#genes_list').DataTable({
+      "paging":   false,
+      "searching": false,
+      "info": false
+    });
+  });
+  </script>
+{% endblock %}

--- a/puzzle/blueprints/variants/templates/sv_variants.html
+++ b/puzzle/blueprints/variants/templates/sv_variants.html
@@ -63,13 +63,14 @@
 
 {% block js_bottom %}
 	{{ super() }}
-	<script type="text/javascript" charset="utf-8">
-		$('.selectpicker').selectpicker();
-		$(document).ready(function(){
+  <script type="text/javascript" charset="utf-8">
+  $('.selectpicker').selectpicker();
+  $(document).ready(function(){
     $('#variants_list').DataTable({
-					"paging":   false,
-					"searching": false
-				});
-		});
-	</script>
+      "paging":   false,
+      "searching": false,
+			"info": false
+    });
+   });
+  </script>
 {% endblock %}

--- a/puzzle/blueprints/variants/templates/sv_variants.html
+++ b/puzzle/blueprints/variants/templates/sv_variants.html
@@ -20,7 +20,7 @@
 	</div>
 
 	<div class="table-responsive">
-		<table class="table table-bordered table-hover">
+		<table class="table table-bordered table-hover" id="variants_list">
 			<thead>
 				<tr>
 					<th>Rank#</th>
@@ -65,5 +65,11 @@
 	{{ super() }}
 	<script type="text/javascript" charset="utf-8">
 		$('.selectpicker').selectpicker();
+		$(document).ready(function(){
+    $('#variants_list').DataTable({
+					"paging":   false,
+					"searching": false
+				});
+		});
 	</script>
 {% endblock %}

--- a/puzzle/blueprints/variants/templates/variant.html
+++ b/puzzle/blueprints/variants/templates/variant.html
@@ -162,3 +162,26 @@
 	</div>
 	{% endif %}
 {% endblock %}
+
+{% block js_bottom %}
+  {{ super() }}
+  <script type="text/javascript" charset="utf-8">
+  $(document).ready(function(){
+    $('#genes_list').DataTable({
+      "paging":   false,
+      "searching": false,
+      "info": false
+    });
+    $('#transcripts_list').DataTable({
+      "paging":   false,
+      "searching": false,
+      "info": false
+    });
+    $('#compounds_list').DataTable({
+      "paging":   false,
+      "searching": false,
+      "info": false
+    });
+  });
+  </script>
+{% endblock %}

--- a/puzzle/blueprints/variants/templates/variants.html
+++ b/puzzle/blueprints/variants/templates/variants.html
@@ -20,7 +20,7 @@
 	</div>
 
 	<div class="table-responsive">
-		<table class="table table-bordered table-hover">
+		<table class="table table-bordered table-hover" id="variants_list">
 			<thead>
 				<tr>
 					<th>Rank #</th>
@@ -63,5 +63,11 @@
 	{{ super() }}
 	<script type="text/javascript" charset="utf-8">
 		$('.selectpicker').selectpicker();
+		$(document).ready(function(){
+    $('#variants_list').DataTable({
+					"paging":   false,
+					"searching": false
+				});
+		});
 	</script>
 {% endblock %}

--- a/puzzle/blueprints/variants/templates/variants.html
+++ b/puzzle/blueprints/variants/templates/variants.html
@@ -62,12 +62,13 @@
 {% block js_bottom %}
 	{{ super() }}
 	<script type="text/javascript" charset="utf-8">
-		$('.selectpicker').selectpicker();
-		$(document).ready(function(){
+  $('.selectpicker').selectpicker();
+  $(document).ready(function(){
     $('#variants_list').DataTable({
-					"paging":   false,
-					"searching": false
-				});
-		});
-	</script>
+      "paging":   false,
+      "searching": false,
+      "info": false
+    });
+  });
+  </script>
 {% endblock %}

--- a/puzzle/templates/layouts/base.html
+++ b/puzzle/templates/layouts/base.html
@@ -19,6 +19,7 @@
 	{% block js_top %}
 		<!-- Latest compiled and minified CSS -->
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+		<link rel="stylesheet" href="https://cdn.datatables.net/1.10.10/css/dataTables.bootstrap.min.css">
 
 		<!-- Optional theme -->
 		<link rel="stylesheet" href="https://bootswatch.com/simplex/bootstrap.min.css">
@@ -51,6 +52,8 @@
 	{% block js_bottom %}
 		<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+		<script src="https://cdn.datatables.net/1.10.10/js/jquery.dataTables.min.js"></script>
+		<script src="https://cdn.datatables.net/1.10.10/js/dataTables.bootstrap.min.js"></script>
 
 		<!-- Latest compiled and minified JavaScript -->
 		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>


### PR DESCRIPTION
Clean PR for this - related discussion in #90. Added data tables to `variants.html` and `sv_variants.html` for now, and prepared the others. However, now that the `genes` and `transcripts` are in separate macros - the call to dataTable from here comes _before_ the loading of jQuery. That won't work.

* [x] ~~Solve loading order of jQuery vs individual dataTable calls~~
  _This was not actually a problem, just me misunderstanding the templating functions_

* [ ] Decide on which features to enable in dataTables