### PR TITLE
Default to empty string if there is no GEMINI query

### DIFF
--- a/puzzle/server/blueprints/variants/templates/macros/filters.html
+++ b/puzzle/server/blueprints/variants/templates/macros/filters.html
@@ -43,7 +43,7 @@
 
           <div class="col-md-6">
             <label class="control-label">Gemini Query</label>
-            <input type="text" class="form-control" name="gemini_query" placeholder="SELECT * variants" value="{{ filters.gemini_query }}">
+            <input type="text" class="form-control" name="gemini_query" placeholder="SELECT * variants" value="{{ filters.gemini_query or '' }}">
           </div>
       </div>
     </div>

--- a/puzzle/server/blueprints/variants/templates/macros/filters.html
+++ b/puzzle/server/blueprints/variants/templates/macros/filters.html
@@ -43,7 +43,7 @@
 
           <div class="col-md-6">
             <label class="control-label">Gemini Query</label>
-            <input type="text" class="form-control" name="gemini_query" placeholder="SELECT * variants" value="{{ filters.gemini_query or '' }}">
+            <input type="text" class="form-control" name="gemini_query" placeholder="SELECT * variants" value="{{ filters.gemini_query if filters.gemini_query }}">
           </div>
       </div>
     </div>


### PR DESCRIPTION
Hi,

I noticed that when loaded a GEMINI db, the Gemini Query filter was populated with the string `None`:

![screen shot 2016-02-25 at 15 16 00](https://cloud.githubusercontent.com/assets/1574147/13322032/c07666fe-dbd2-11e5-8adb-372c27b161f6.png)

Causing puzzle to crash on any other filtering:

```
...
  File "/Users/guillem/anaconda/envs/master/lib/python2.7/site-packages/gemini/GeminiQuery.py", line 854, in _execute_query
    sys.exit("The query issued (%s) has a syntax error." % self.query)
SystemExit: The query issued (None) has a syntax error.
...
```

This should fix the problem :-)

![screen shot 2016-02-25 at 15 17 37](https://cloud.githubusercontent.com/assets/1574147/13322071/edf98d22-dbd2-11e5-9af9-dc241e3abbdd.png)
