### PR TITLE
Use max AF - max of variant.frequency - for variants display.

### DIFF
--- a/puzzle/plugins/vcf/variant_mixin.py
+++ b/puzzle/plugins/vcf/variant_mixin.py
@@ -455,18 +455,27 @@ class VariantMixin(BaseVariantMixin):
 
         # Add transcript information:
         gmaf = None
+        exac = None
         if vep_string:
             for transcript_info in vep_info:
                 transcript = self._get_vep_transcripts(transcript_info)
                 gmaf_raw = transcript_info.get('GMAF')
                 if gmaf_raw:
                     gmaf = float(gmaf_raw.split(':')[-1])
+
+                exac_raw = transcript_info.get('ExAC_MAF')
+                if exac_raw:
+                    exac = float(exac_raw.split(':')[-1])
+
                 variant.add_transcript(transcript)
 
         if gmaf:
             variant.add_frequency('GMAF', gmaf)
             if not variant.thousand_g:
                 variant.thousand_g = gmaf
+
+        if exac:
+            variant.add_frequency('ExAC', exac)
 
         elif snpeff_string:
             for transcript_info in snpeff_info:

--- a/puzzle/server/blueprints/variants/templates/variants.html
+++ b/puzzle/server/blueprints/variants/templates/variants.html
@@ -27,8 +27,8 @@
           <th>Score</th>
           <th>Chromosome</th>
           <th>Gene</th>
-          <th>Consequence</th>
-          <th>1000G</th>
+          <th>Consequence</th>	  
+          <th>MaxAF</th>
           <th>CADD</th>
         </tr>
       </thead>
@@ -40,12 +40,18 @@
             <td>{{ variant.CHROM }}</td>
             <td>{{ omim_links(variant.genes) }}</td>
             <td>{{ variant.most_severe_consequence or '-' }}</td>
-            <td>
-              {% if variant.thousand_g %}
-                {{ variant.thousand_g|round(4) }}
+            <td>	     
+	      {% for frequency in variant.frequencies %}
+                {% set freq=0 %}
+                  {% if frequency.value > freq %}
+                    {% set freq=frequency.value %}	        
+	          {% endif %}
+	        {% if loop.last %}
+	           {{ freq }}
+	        {% endif %}
               {% else %}
                 <small class="text-muted">-</small>
-              {% endif %}
+	      {% endfor %}
             </td>
             <td>{{ variant.cadd_score or '-' }}</td>
           </tr>

--- a/puzzle/server/blueprints/variants/templates/variants.html
+++ b/puzzle/server/blueprints/variants/templates/variants.html
@@ -47,7 +47,7 @@
                     {% set freq=frequency.value %}	        
 	          {% endif %}
 	        {% if loop.last %}
-	           {{ freq }}
+	           {{ freq|round(4) }}
 	        {% endif %}
               {% else %}
                 <small class="text-muted">-</small>


### PR DESCRIPTION
Pop_freq_max in the annotations files - or from the variant adaptor - would be faster, but this is kind of fun. Also use ExAC_MAF from VEP vcf if available.