### PR TITLE
Filter fixes: enable SV len filter and max_freq setting on VCF.

### DIFF
--- a/puzzle/plugins/vcf/variant_mixin.py
+++ b/puzzle/plugins/vcf/variant_mixin.py
@@ -456,6 +456,7 @@ class VariantMixin(BaseVariantMixin):
         # Add transcript information:
         gmaf = None
         exac = None
+        max_freq = None
         if vep_string:
             for transcript_info in vep_info:
                 transcript = self._get_vep_transcripts(transcript_info)
@@ -466,6 +467,10 @@ class VariantMixin(BaseVariantMixin):
                 exac_raw = transcript_info.get('ExAC_MAF')
                 if exac_raw:
                     exac = float(exac_raw.split(':')[-1])
+
+                max_freq_raw = transcript_info.get('pop_freq_max')
+                if max_freq_raw:
+                    max_freq = float(max_freq_raw.split(':')[-1])
 
                 variant.add_transcript(transcript)
 
@@ -481,6 +486,11 @@ class VariantMixin(BaseVariantMixin):
             for transcript_info in snpeff_info:
                 transcript = self._get_snpeff_transcripts(transcript_info)
                 variant.add_transcript(transcript)
+
+        if max_freq:
+            variant.set_max_freq(max_freq)
+        else:
+            variant.set_max_freq()
 
         most_severe_consequence = get_most_severe_consequence(
             variant['transcripts']

--- a/puzzle/plugins/vcf/vcf.py
+++ b/puzzle/plugins/vcf/vcf.py
@@ -65,7 +65,6 @@ class VcfPlugin(VariantMixin, CaseMixin, Plugin):
                     self.individuals.append(ind)
 
         # check vcf header for datatypes supported by filters?
-        print "DEBUG: setting can_filter!\n"
         self.filters = DotDict(
             can_filter_frequency=True,
             can_filter_cadd=True,

--- a/puzzle/plugins/vcf/vcf.py
+++ b/puzzle/plugins/vcf/vcf.py
@@ -64,6 +64,8 @@ class VcfPlugin(VariantMixin, CaseMixin, Plugin):
                 for ind in case_obj.individuals:
                     self.individuals.append(ind)
 
+        # check vcf header for datatypes supported by filters?
+        print "DEBUG: setting can_filter!\n"
         self.filters = DotDict(
             can_filter_frequency=True,
             can_filter_cadd=True,
@@ -71,8 +73,8 @@ class VcfPlugin(VariantMixin, CaseMixin, Plugin):
             can_filter_gene=True,
             can_filter_inheritance=True,
             can_filter_sv=True,
-            can_filter_impact_severity=True
-            
+            can_filter_sv_len=True,
+            can_filter_impact_severity=True 
         )
 
     def check_setup(self, case_lines):

--- a/puzzle/server/blueprints/variants/templates/macros/filters.html
+++ b/puzzle/server/blueprints/variants/templates/macros/filters.html
@@ -16,7 +16,7 @@
           <input type="text" class="form-control" name="cadd" type="number" placeholder="23.4" step="0.1" value="{{ filters.cadd or '' }}">
         </div>
       {% endif %}
-      {% if db.filters.can_filter_sv_len %}
+      {% if db.filters.can_filter_sv_len and db.variant_type == 'sv'%}
         <div class="col-md-4">
           <label class="control-label">SV Len</label>
           <input type="text" class="form-control" name="sv_len" type="number" placeholder="23.4" step="0.1" value="{{ filters.sv_len or '' }}">
@@ -28,7 +28,6 @@
   {% if db.filters.can_filter_gene %}
     <div class="form-group">
       <div class="row">
-
           <div class="col-md-12">
             <label class="control-label">Genes</label>
             <input type="text" class="form-control" name="gene_symbol" placeholder="ADK,LPP" value="{{ (filters.gene_symbols or '')|join(',') }}">

--- a/puzzle/server/blueprints/variants/templates/sv_variants.html
+++ b/puzzle/server/blueprints/variants/templates/sv_variants.html
@@ -45,7 +45,7 @@
             <td>{{ variant.nr_genes }}</td>
             <td>
               {% if variant.genes|length >= 5 %}
-                {{ omim_links(variant.genes[:2]) }} [...] {{ omim_links(variant.genes[-2:]) }}
+                {{ omim_links(variant.genes[:2]) }} <a href="{{ url_for('variants.variant', case_id=case_id, variant_id=variant.variant_id) }}">[...]</a> {{ omim_links(variant.genes[-2:]) }}
               {% else %}
                 {{ omim_links(variant.genes) }}
               {% endif %}

--- a/puzzle/server/blueprints/variants/templates/sv_variants.html
+++ b/puzzle/server/blueprints/variants/templates/sv_variants.html
@@ -29,6 +29,7 @@
           <th>Start Loc</th>
           <th>Stop Loc</th>
           <th>Length</th>
+	  <th>Freq</th>
           <th>Nr Genes</th>
           <th>Gene</th>
         </tr>
@@ -42,6 +43,17 @@
             <td>{{ variant.cytoband_start or '-' }}</td>
             <td>{{ variant.cytoband_stop or '-' }}</td>
             <td align="right">{{ '{0:,}'.format(variant.sv_len) }}</td>
+	    <td> 
+	      {% if(variant.max_freq) %}
+	        {% if(variant.max_freq >= 1) %}
+	          {{ variant.max_freq }}
+	        {% else %}
+         	  {{ variant.max_freq|round(3) }}
+	        {% endif %}
+	      {% else %}
+                  <small class="text-muted">-</small>
+              {% endif %}
+	      </td> 
             <td>{{ variant.nr_genes }}</td>
             <td>
               {% if variant.genes|length >= 5 %}

--- a/puzzle/server/blueprints/variants/templates/variants.html
+++ b/puzzle/server/blueprints/variants/templates/variants.html
@@ -28,7 +28,7 @@
           <th>Chromosome</th>
           <th>Gene</th>
           <th>Consequence</th>	  
-          <th>MaxAF</th>
+          <th>Max AF</th>
           <th>CADD</th>
         </tr>
       </thead>
@@ -40,19 +40,14 @@
             <td>{{ variant.CHROM }}</td>
             <td>{{ omim_links(variant.genes) }}</td>
             <td>{{ variant.most_severe_consequence or '-' }}</td>
-            <td>	     
-	      {% for frequency in variant.frequencies %}
-                {% set freq=0 %}
-                  {% if frequency.value > freq %}
-                    {% set freq=frequency.value %}	        
-	          {% endif %}
-	        {% if loop.last %}
-	           {{ freq|round(4) }}
-	        {% endif %}
-              {% else %}
-                <small class="text-muted">-</small>
-	      {% endfor %}
+            <td>
+	      {% if(variant.max_freq) %}
+	         {{ variant.max_freq|round(4) }}
+	      {% else %}
+	          <small class="text-muted">-</small>
+              {% endif %}
             </td>
+
             <td>{{ variant.cadd_score or '-' }}</td>
           </tr>
         {% else %}


### PR DESCRIPTION
SV len filter was turned off by default. Also, max_freq was not set for variants pulled through VCF adaptor.

Snuck in SV variant freq display already at the SV variants page, and an extra link to better indicate that there (may) be more OMIM genes hiding in a multi gene event than meets the eye on the variants list.