### PR TITLE
Notify if HPO not found or repeated

### DIFF
--- a/puzzle/cli/view.py
+++ b/puzzle/cli/view.py
@@ -5,7 +5,7 @@ import webbrowser
 import click
 import logging
 
-from . import (base, family_file, family_type, version, root, mode, 
+from . import (base, family_file, family_type, version, root, mode,
                variant_type, phenomizer)
 
 from puzzle.plugins import SqlStore, VcfPlugin
@@ -59,6 +59,7 @@ def view(ctx, host, port, debug, pattern, family_file, family_type,
             logger.warn("database not initialized, run 'puzzle init'")
             ctx.abort()
         phenomizer_auth = phenomizer or ctx.obj.get('phenomizer_auth')
+        BaseConfig.PHENOMIZER_AUTH = True if ctx.obj.get('phenomizer_auth') else False
         plugin = SqlStore(db_path, phenomizer_auth=phenomizer_auth)
         BaseConfig.STORE_ENABLED = True
 

--- a/puzzle/plugins/sql/mixins/actions/phenotype.py
+++ b/puzzle/plugins/sql/mixins/actions/phenotype.py
@@ -19,7 +19,7 @@ class PhenotypeActions(object):
             logger.debug('querying on OMIM term')
             hpo_results = phizz.query_disease([phenotype_id])
 
-        added_terms = []
+        added_terms = [] if hpo_results else None
         existing_ids = set(term.phenotype_id for term in ind_obj.phenotypes)
         for result in hpo_results:
             if result['hpo_term'] not in existing_ids:
@@ -32,7 +32,7 @@ class PhenotypeActions(object):
         logger.debug('storing new HPO terms')
         self.save()
 
-        if len(added_terms) > 0:
+        if added_terms is not None and len(added_terms) > 0:
             self.update_hpolist(ind_obj.ind_id)
 
         return added_terms

--- a/puzzle/server/blueprints/public/templates/case.html
+++ b/puzzle/server/blueprints/public/templates/case.html
@@ -45,11 +45,11 @@
   </div>
 </div>
 
-{% if config['STORE_ENABLED'] %}
+{% if config['STORE_ENABLED'] and config['PHENOMIZER_AUTH'] %}
   <div class="panel panel-default">
     <div class="panel-heading"><a href="http://compbio.charite.de/hpoweb/showterm?id=HP:0000118" target="_blank">Phenotypes</a></div>
-    
-    
+
+
     <div class="panel-body">
       <div class="row">
         <div class="col-md-8">

--- a/puzzle/server/blueprints/public/templates/case.html
+++ b/puzzle/server/blueprints/public/templates/case.html
@@ -60,6 +60,20 @@
           {{ public_utils.phenotype_form(individuals=case.individuals) }}
         </div>
       </div>
+      
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          {% for category, message in messages %}
+          <div class="alert alert-{{ category }} alert-dismissible" role="alert">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+            {{ message }}
+          </div>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+
     </div>
   </div>
 

--- a/puzzle/server/blueprints/public/views.py
+++ b/puzzle/server/blueprints/public/views.py
@@ -3,7 +3,7 @@ import os
 
 from flask import (abort, Blueprint, current_app as app, render_template,
                    redirect, request, url_for, make_response,
-                   send_from_directory)
+                   send_from_directory, flash)
 from werkzeug import secure_filename
 
 BP_NAME = __name__.split('.')[-2]
@@ -38,7 +38,11 @@ def phenotypes():
 
     ind_obj = app.db.individual(ind_id)
     try:
-        app.db.add_phenotype(ind_obj, phenotype_id)
+        added_terms = app.db.add_phenotype(ind_obj, phenotype_id)
+        if added_terms is None:
+            flash("Term with id {} was not found".format(phenotype_id), 'danger')
+        elif added_terms == []:
+            flash("Term with id {} was already added".format(phenotype_id), 'warning')
     except RuntimeError as error:
         return abort(500, error.message)
 

--- a/puzzle/server/settings.py
+++ b/puzzle/server/settings.py
@@ -18,6 +18,8 @@ class BaseConfig:
     # default blueprints
     BLUEPRINTS = [public_bp, variants_bp]
 
+    #Phemonizer credentials
+    PHENOMIZER_AUTH = False
 
 class DevConfig(BaseConfig):
     DEBUG = True

--- a/tests/plugins/mixins/test_mixin_phenotype.py
+++ b/tests/plugins/mixins/test_mixin_phenotype.py
@@ -21,6 +21,10 @@ def test_add_phenotype(test_db, phenomizer_auth):
 
     # test with a missing HPO id
     hpo_id = 'HP:0000118'
+    assert test_db.add_phenotype(ind_obj, hpo_id) is None
+
+    # test with a repeated HPO id
+    hpo_id = 'HP:0002497'
     assert test_db.add_phenotype(ind_obj, hpo_id) == []
 
     # test adding with OMIM id


### PR DESCRIPTION
Hi!

This fixes the two issues mentioned in the commits. I decided to also notify the user if the HPO term added was already in the list, doesn't hurt :-) Some screenshots (I like screenshots..):

* User adds HPO term that is not found:

![screen shot 2016-03-04 at 15 28 04](https://cloud.githubusercontent.com/assets/1574147/13530012/70528038-e21f-11e5-8fa1-4f949e944a13.png)

* User adds a existent HPO term

![screen shot 2016-03-04 at 15 28 23](https://cloud.githubusercontent.com/assets/1574147/13530009/67c88390-e21f-11e5-9eb4-bf7a79c0f21e.png)

Yell if you don't like the logic in `phenotype.py`. Basically if no HPO term is found will return `None`, otherwise will return a list as before.