### PR TITLE
Don't open browser if --no-browser is True

### DIFF
--- a/puzzle/cli/view.py
+++ b/puzzle/cli/view.py
@@ -135,7 +135,7 @@ def view(ctx, host, port, debug, pattern, family_file, family_type,
 
     app = create_app(config_obj=BaseConfig)
 
-    if not debug or ((not no_browser) and (not main_loop)):
+    if no_browser is False:
         webbrowser.open_new_tab("http://{}:{}".format(host, port))
 
     app.run(host=host, port=port, debug=debug)


### PR DESCRIPTION
Shouldn't this be simpler? Puzzle opens the browser if I use `puzzle view --no-browser /path/to/gemini.db` even if `--no-browser` is set. I have to launch it in debug mode so that it doesn't open the browser. 